### PR TITLE
feat: add abstract nodeowner interface

### DIFF
--- a/contracts/AbstractNodeOwner.sol
+++ b/contracts/AbstractNodeOwner.sol
@@ -1,0 +1,11 @@
+pragma solidity ^0.5.3;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+/// @title NodeOwner interface
+/// @notice Defines an interface for the NodeOwner implementation.
+contract AbstractNodeOwner is IERC721 {
+    function available (uint256 tokenId) public view returns(bool);
+    function reclaim(uint256 tokenId, address newOwner) external;
+    function removeExpired(uint256[] calldata tokenIds) external;
+}

--- a/contracts/NodeOwner.sol
+++ b/contracts/NodeOwner.sol
@@ -4,8 +4,9 @@ import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 import "@openzeppelin/contracts/ownership/Ownable.sol";
 import "@openzeppelin/contracts/access/Roles.sol";
 import "@rsksmart/rns-registry/contracts/AbstractRNS.sol";
+import "./AbstractNodeOwner.sol";
 
-contract NodeOwner is ERC721, Ownable {
+contract NodeOwner is ERC721, Ownable, AbstractNodeOwner {
     using Roles for Roles.Role;
 
     AbstractRNS private rns;


### PR DESCRIPTION
* Implements the `AbstractNodeOwner` interface which is required by the RIF Marketplace.
 Closes #56 